### PR TITLE
[feat]: v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azuma",
-  "version": "3.0.5",
+  "version": "4.0.0-dev",
   "description": "A package that actually syncs your ratelimits across all your clusters on Discord.JS",
   "type":"module",
   "main": "index.js",


### PR DESCRIPTION
Azuma v4 will drop support for Kurasuta, and will support Indomitable. 

V4 aims to still sync your ratelimits on the least amount of effort possible


Todo:
- [ ] Structure
- [ ] Tests
